### PR TITLE
Update `useCallback` example to clarify parent

### DIFF
--- a/src/docs/useCallback.mdx
+++ b/src/docs/useCallback.mdx
@@ -23,8 +23,8 @@ The following example will form the basis of the explanations and code snippets 
 
 <Editor noInline code={Starter} />
 
-In the example above, the parent component, `<Age />` is updated (and re-rendered) whenever the "Get older" button is clicked.
-Consequently, the `<Instructions />` child component is also re-rendered because the `doSomething` prop is passed a
+In the example above, the parent component, `<App />` is updated (and re-rendered) whenever the "Get older" button is clicked.
+Consequently, `<Age />` and `<Instructions />` child components are also re-rendered. `<Instructions />` is re-rendered because the `doSomething` prop is passed a
 new callback, with a new reference. This can be seen from the random text colour which changes whenever the state value `age` is updated.
 
 > NB: Even though the `Instructions` child component uses `React.memo` to optimize performance, it is still re-rendered.


### PR DESCRIPTION
Update paragraph to indicate that `<App />` is the parent.